### PR TITLE
feat: support `sql.Scanner` and `sql.Valuer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,27 @@ The enums can have additional functionality added by just adding comments to the
 For example we have the file below called planets.go :
 
 ```golang
+package milkyway
 
+type planet int // Gravity[float64],RadiusKm[float64],MassKg[float64],OrbitKm[float64],OrbitDays[float64],SurfacePressureBars[float64],Moons[int],Rings[bool]
+
+//go:generate goenums -file planets.go
+const (
+	unknown planet = iota // invalid
+	mercury               // Mercury 0.378,2439.7,3.3e23,57910000,88,0.0000000001,0,false
+	venus                 // Venus 0.907,6051.8,4.87e24,108200000,225,92,0,false
+	earth                 // Earth 1,6378.1,5.97e24,149600000,365,1,1,false
+	mars                  // Mars 0.377,3389.5,6.42e23,227900000,687,0.01,2,false
+	jupiter               // Jupiter 2.36,69911,1.90e27,778600000,4333,20,4,true
+	saturn                // Saturn 0.916,58232,5.68e26,1433500000,10759,1,7,true
+	uranus                // Uranus 0.889,25362,8.68e25,2872500000,30687,1.3,13,true
+	neptune               // Neptune 1.12,24622,1.02e26,4495100000,60190,1.5,2,true
+)
+```
+
+Now running the `go generate` command will generate the following code in a new file called `planet_enum.go`:
+
+```golang
 type Planet struct {
 	planet
 	Gravity             float64

--- a/README.md
+++ b/README.md
@@ -226,18 +226,17 @@ The enums can have additional functionality added by just adding comments to the
 For example we have the file below called planets.go :
 
 ```golang
-package milkywaysimple
-
-import (
-	"bytes"
-	"database/sql/driver"
-	"fmt"
-	"strconv"
-	"strings"
-)
 
 type Planet struct {
 	planet
+	Gravity             float64
+	RadiusKm            float64
+	MassKg              float64
+	OrbitKm             float64
+	OrbitDays           float64
+	SurfacePressureBars float64
+	Moons               int
+	Rings               bool
 }
 
 type planetContainer struct {
@@ -254,28 +253,92 @@ type planetContainer struct {
 
 var Planets = planetContainer{
 	MERCURY: Planet{
-		planet: mercury,
+		planet:              mercury,
+		Gravity:             0.378,
+		RadiusKm:            2439.7,
+		MassKg:              3.3e23,
+		OrbitKm:             57910000,
+		OrbitDays:           88,
+		SurfacePressureBars: 0.0000000001,
+		Moons:               0,
+		Rings:               false,
 	},
 	VENUS: Planet{
-		planet: venus,
+		planet:              venus,
+		Gravity:             0.907,
+		RadiusKm:            6051.8,
+		MassKg:              4.87e24,
+		OrbitKm:             108200000,
+		OrbitDays:           225,
+		SurfacePressureBars: 92,
+		Moons:               0,
+		Rings:               false,
 	},
 	EARTH: Planet{
-		planet: earth,
+		planet:              earth,
+		Gravity:             1,
+		RadiusKm:            6378.1,
+		MassKg:              5.97e24,
+		OrbitKm:             149600000,
+		OrbitDays:           365,
+		SurfacePressureBars: 1,
+		Moons:               1,
+		Rings:               false,
 	},
 	MARS: Planet{
-		planet: mars,
+		planet:              mars,
+		Gravity:             0.377,
+		RadiusKm:            3389.5,
+		MassKg:              6.42e23,
+		OrbitKm:             227900000,
+		OrbitDays:           687,
+		SurfacePressureBars: 0.01,
+		Moons:               2,
+		Rings:               false,
 	},
 	JUPITER: Planet{
-		planet: jupiter,
+		planet:              jupiter,
+		Gravity:             2.36,
+		RadiusKm:            69911,
+		MassKg:              1.90e27,
+		OrbitKm:             778600000,
+		OrbitDays:           4333,
+		SurfacePressureBars: 20,
+		Moons:               4,
+		Rings:               true,
 	},
 	SATURN: Planet{
-		planet: saturn,
+		planet:              saturn,
+		Gravity:             0.916,
+		RadiusKm:            58232,
+		MassKg:              5.68e26,
+		OrbitKm:             1433500000,
+		OrbitDays:           10759,
+		SurfacePressureBars: 1,
+		Moons:               7,
+		Rings:               true,
 	},
 	URANUS: Planet{
-		planet: uranus,
+		planet:              uranus,
+		Gravity:             0.889,
+		RadiusKm:            25362,
+		MassKg:              8.68e25,
+		OrbitKm:             2872500000,
+		OrbitDays:           30687,
+		SurfacePressureBars: 1.3,
+		Moons:               13,
+		Rings:               true,
 	},
 	NEPTUNE: Planet{
-		planet: neptune,
+		planet:              neptune,
+		Gravity:             1.12,
+		RadiusKm:            24622,
+		MassKg:              1.02e26,
+		OrbitKm:             4495100000,
+		OrbitDays:           60190,
+		SurfacePressureBars: 1.5,
+		Moons:               2,
+		Rings:               true,
 	},
 }
 
@@ -383,7 +446,7 @@ func (p *Planet) Scan(value any) error {
 }
 
 func (p Planet) Value() (driver.Value, error) {
-	return int64(p.planet), nil
+	return p.String(), nil
 }
 
 func _() {
@@ -402,7 +465,7 @@ func _() {
 	_ = x[neptune-8]
 }
 
-const _planet_name = "unknownmercuryvenusearthmarsjupitersaturnuranusneptune"
+const _planet_name = "unknownMercuryVenusEarthMarsJupiterSaturnUranusNeptune"
 
 var _planet_index = [...]uint16{0, 7, 14, 19, 24, 28, 35, 41, 47, 54}
 
@@ -412,6 +475,7 @@ func (i planet) String() string {
 	}
 	return _planet_name[_planet_index[i]:_planet_index[i+1]]
 }
+
 ```
 
 With the above code generated we can use the `ExhaustivePlanets` to iterate over all Enums for example:

--- a/examples/milkyway/planet_enum.go
+++ b/examples/milkyway/planet_enum.go
@@ -7,6 +7,7 @@ package milkyway
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"fmt"
 	"strconv"
 	"strings"
@@ -146,6 +147,8 @@ func ParsePlanet(a any) Planet {
 	switch v := a.(type) {
 	case Planet:
 		return v
+	case []byte:
+		return stringToPlanet(string(v))
 	case string:
 		return stringToPlanet(v)
 	case fmt.Stringer:
@@ -221,6 +224,15 @@ func (p *Planet) UnmarshalJSON(b []byte) error {
 	b = bytes.Trim(bytes.Trim(b, `"`), ` `)
 	*p = ParsePlanet(string(b))
 	return nil
+}
+
+func (p *Planet) Scan(value any) error {
+	*p = ParsePlanet(value)
+	return nil
+}
+
+func (p Planet) Value() (driver.Value, error) {
+	return p.String(), nil
 }
 
 func _() {

--- a/examples/milkyway/planets.go
+++ b/examples/milkyway/planets.go
@@ -2,7 +2,7 @@ package milkyway
 
 type planet int // Gravity[float64],RadiusKm[float64],MassKg[float64],OrbitKm[float64],OrbitDays[float64],SurfacePressureBars[float64],Moons[int],Rings[bool]
 
-//go:generate goenums planets.go
+//go:generate goenums -file planets.go
 const (
 	unknown planet = iota // invalid
 	mercury               // Mercury 0.378,2439.7,3.3e23,57910000,88,0.0000000001,0,false

--- a/examples/milkywaysimple/planet_enum.go
+++ b/examples/milkywaysimple/planet_enum.go
@@ -7,6 +7,7 @@ package milkywaysimple
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,6 +75,8 @@ func ParsePlanet(a any) Planet {
 	switch v := a.(type) {
 	case Planet:
 		return v
+	case []byte:
+		return stringToPlanet(string(v))
 	case string:
 		return stringToPlanet(v)
 	case fmt.Stringer:
@@ -149,6 +152,15 @@ func (p *Planet) UnmarshalJSON(b []byte) error {
 	b = bytes.Trim(bytes.Trim(b, `"`), ` `)
 	*p = ParsePlanet(string(b))
 	return nil
+}
+
+func (p *Planet) Scan(value any) error {
+	*p = ParsePlanet(value)
+	return nil
+}
+
+func (p Planet) Value() (driver.Value, error) {
+	return int64(p.planet), nil
 }
 
 func _() {

--- a/examples/milkywaysimple/planets.go
+++ b/examples/milkywaysimple/planets.go
@@ -2,7 +2,7 @@ package milkywaysimple
 
 type planet int
 
-//go:generate goenums planets.go
+//go:generate goenums -file planets.go
 const (
 	unknown planet = iota // invalid
 	mercury

--- a/examples/status/status.go
+++ b/examples/status/status.go
@@ -2,7 +2,7 @@ package validation
 
 type status int
 
-//go:generate goenums status.go
+//go:generate goenums -file status.go
 const (
 	unknown status = iota
 	failed

--- a/examples/status/status_enum.go
+++ b/examples/status/status_enum.go
@@ -7,6 +7,7 @@ package validation
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"fmt"
 	"strconv"
 	"strings"
@@ -68,6 +69,8 @@ func ParseStatus(a any) Status {
 	switch v := a.(type) {
 	case Status:
 		return v
+	case []byte:
+		return stringToStatus(string(v))
 	case string:
 		return stringToStatus(v)
 	case fmt.Stringer:
@@ -138,6 +141,15 @@ func (p *Status) UnmarshalJSON(b []byte) error {
 	b = bytes.Trim(bytes.Trim(b, `"`), ` `)
 	*p = ParseStatus(string(b))
 	return nil
+}
+
+func (p *Status) Scan(value any) error {
+	*p = ParseStatus(value)
+	return nil
+}
+
+func (p Status) Value() (driver.Value, error) {
+	return p.String(), nil
 }
 
 func _() {

--- a/goenums.go
+++ b/goenums.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	fileName   = flag.String("file", "", "Path to the file to generate enums from")
-	valuerType = flag.String("valuer", "string", "Type of the valuer interface implementation, support int and string, default to string")
+	valuerType = flag.String("valuer", "string", "The return value type of db valuer implementation, support int and string")
 )
 
 func main() {

--- a/goenums.go
+++ b/goenums.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -8,20 +9,28 @@ import (
 	"github.com/zarldev/goenums/pkg/generator"
 )
 
+var (
+	fileName   = flag.String("file", "", "Path to the file to generate enums from")
+	valuerType = flag.String("valuer", "string", "Type of the valuer interface implementation, support int and string, default to string")
+)
+
 func main() {
-	var err error
-	if len(os.Args) != 2 {
-		printHelp()
-		return
+	flag.Parse()
+
+	if fileName == nil || *fileName == "" {
+		fmt.Printf("Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(1)
 	}
-	filename := os.Args[1]
-	err = generator.ParseAndGenerate(filename)
+
+	options := &generator.GenerateOptions{
+		FileName:   *fileName,
+		ValuerType: *valuerType,
+	}
+
+	err := generator.ParseAndGenerate(options)
 	if err != nil {
 		slog.Error("Failed to generate enums: %v", err)
 		os.Exit(1)
 	}
-}
-
-func printHelp() {
-	fmt.Println("Usage: goenums <filename.go>")
 }


### PR DESCRIPTION
`database/sql` is the standardized and the most widely used custom type definition protocol among go world, including [GORM](https://gorm.io/docs/data_types.html#Scanner-x2F-Valuer) and [pgx](https://pkg.go.dev/github.com/jackc/pgx/v5#readme-choosing-between-the-pgx-and-database-sql-interfaces) supports it.

This PR added those features to support seamlessly `sql.Scanner` and `sql.Valuer` support, including:
- Generate `(*XXX).Scan` and `(XXX).Value` methods.
- Add `[]byte` type in `ParseXXX` function, treat `[]byte` as byte string.
- Add options to switch `int` or `string`(corresponding to `int` and `varchar/text` in database) as `valuer` implementations.

As per change, `README.md` is updated, and using `flag` to parse cli options.

As for nullable columns, it's should be trivial to support it since go1.22 introduced [`sql.Null[T]`](https://pkg.go.dev/database/sql#Null), so this PR do not introduce `NullXXX` types.