### PR TITLE
fix(build): restore Makefile BUILD_TIME/GIT_COMMIT newline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Build variables
 VERSION := v0.5.0
-BUILD_TIME := $(shell date +%Y%m%d-%H:%M:%S)GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME := $(shell date +%Y%m%d-%H:%M:%S)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_DIRTY := $(shell if [ -n "$$(git status --porcelain)" ]; then echo "-dirty"; fi)
 GOLANGCI_LINT_VERSION := v2.12.1
 


### PR DESCRIPTION
## Summary

A newline was lost between the `BUILD_TIME` and `GIT_COMMIT` assignments in the Makefile, collapsing them onto one line:

```make
BUILD_TIME := $(shell date +%Y%m%d-%H:%M:%S)GIT_COMMIT := $(shell git rev-parse --short HEAD ...)
```

As a result `BUILD_TIME` absorbed the `GIT_COMMIT := …` text, embedding a space and `:=` into the `-X …version.BUILD=` ldflags value. The linker then parsed the fragment after the space as bogus flags and **every `make build*` target failed** (caught while building the v0.5.0 release archives).

## Fix

Split the two assignments back onto separate lines. `make debug-version` and `make release-all` now work.

## Verification
- `make debug-version` → BUILD_TIME and GIT_COMMIT expand independently
- `make release-all` builds all five platform archives